### PR TITLE
SPI interface

### DIFF
--- a/examples/image_spi.rs
+++ b/examples/image_spi.rs
@@ -1,0 +1,92 @@
+//! Draw a 1 bit per pixel black and white image. On a 128x64 sh1106 display over SPI.
+//!
+//! Image was created with ImageMagick:
+//!
+//! ```bash
+//! convert rust.png -depth 1 gray:rust.raw
+//! ```
+//!
+//! This example is for the STM32F103 "Blue Pill" board using SPI.
+//!
+//! Wiring connections are as follows:
+//!
+//! ```
+//!      Display -> Blue Pill
+//!          GND -> GND
+//!          VCC -> 3.3V or 5V (check your module's input voltage)
+//!          SCK -> PA5
+//!         MOSI -> PA7
+//!           DC -> PA2
+//!           CS -> PA1 (optional, connect to ground on module if unused)
+//! ```
+//!
+//! Run on a Blue Pill with `cargo run --example image`.
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal as hal;
+
+use cortex_m_rt::ExceptionFrame;
+use cortex_m_rt::{entry, exception};
+use embedded_hal::spi;
+use embedded_graphics::image::Image1BPP;
+use embedded_graphics::prelude::*;
+use hal::spi::Spi;
+use hal::prelude::*;
+use hal::stm32;
+use sh1106::prelude::*;
+use sh1106::Builder;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+
+    let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
+
+    let sck = gpioa.pa5.into_alternate_push_pull(&mut gpioa.crl);
+    let miso = gpioa.pa6.into_floating_input(&mut gpioa.crl);
+    let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
+    let dc = gpioa.pa2.into_push_pull_output(&mut gpioa.crl);
+    let cs = gpioa.pa1.into_push_pull_output(&mut gpioa.crl);
+
+    let spi = Spi::spi1(
+        dp.SPI1,
+        (sck, miso, mosi),
+        &mut afio.mapr,
+        spi::MODE_0,
+        400.khz(),
+        clocks,
+        &mut rcc.apb2);
+
+    let mut disp: GraphicsMode<_> = Builder::new()
+        .with_spi_cs(cs)
+        .connect_spi(spi, dc)
+        .into();
+
+    disp.init().unwrap();
+    disp.flush().unwrap();
+
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate(Coord::new(32, 0));
+
+    disp.draw(im.into_iter());
+
+    disp.flush().unwrap();
+
+    loop {}
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,15 @@
 //!
 //! # Examples
 //!
+//! Connect over SPI with default rotation (0 deg) and size (128x64):
+//!
+//! ```rust,ignore
+//! let spi = /* SPI interface from your HAL of choice */;
+//! let dc = /* GPIO data/command select pin */;
+//!
+//! Builder::new().connect_spi(spi, dc);
+//! ```
+//!
 //! Connect over I2C, changing lots of options
 //!
 //! ```rust,ignore
@@ -32,10 +41,11 @@
 //! ```
 
 use hal;
+use hal::digital::OutputPin;
 
 use crate::displayrotation::DisplayRotation;
 use crate::displaysize::DisplaySize;
-use crate::interface::I2cInterface;
+use crate::interface::{I2cInterface, SpiInterface};
 use crate::mode::displaymode::DisplayMode;
 use crate::mode::raw::RawMode;
 use crate::properties::DisplayProperties;
@@ -94,5 +104,20 @@ impl Builder {
             self.rotation,
         );
         DisplayMode::<RawMode<I2cInterface<I2C>>>::new(properties)
+    }
+
+    /// Finish the builder and use SPI to communicate with the display
+    pub fn connect_spi<SPI, DC>(
+        &self,
+        spi: SPI,
+        dc: DC,
+    ) -> DisplayMode<RawMode<SpiInterface<SPI, DC>>>
+    where
+        SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
+        DC: OutputPin,
+    {
+        let properties =
+            DisplayProperties::new(SpiInterface::new(spi, dc), self.display_size, self.rotation);
+        DisplayMode::<RawMode<SpiInterface<SPI, DC>>>::new(properties)
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -52,10 +52,11 @@ use crate::properties::DisplayProperties;
 
 /// Builder struct. Driver options and interface are set using its methods.
 #[derive(Clone, Copy)]
-pub struct Builder {
+pub struct Builder<CS=NoOutputPin> {
     display_size: DisplaySize,
     rotation: DisplayRotation,
     i2c_addr: u8,
+    spi_cs: CS,
 }
 
 impl Default for Builder {
@@ -66,35 +67,51 @@ impl Default for Builder {
 
 impl Builder {
     /// Create new builder with a default size of 128 x 64 pixels and no rotation.
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> Builder<NoOutputPin> {
+        Builder {
             display_size: DisplaySize::Display128x64,
             rotation: DisplayRotation::Rotate0,
             i2c_addr: 0x3c,
+            spi_cs: NoOutputPin,
         }
     }
+}
 
+impl<CS> Builder<CS>
+    where CS: OutputPin
+{
     /// Set the size of the display. Supported sizes are defined by [DisplaySize].
-    pub fn with_size(&self, display_size: DisplaySize) -> Self {
-        Self {
-            display_size,
-            ..*self
-        }
+    pub fn with_size(self, display_size: DisplaySize) -> Self {
+        Self { display_size, ..self }
     }
 
     /// Set the I2C address to use. Defaults to 0x3C which is the most common address.
     /// The other address specified in the datasheet is 0x3D. Ignored when using SPI interface.
-    pub fn with_i2c_addr(&self, i2c_addr: u8) -> Self {
-        Self { i2c_addr, ..*self }
+    pub fn with_i2c_addr(self, i2c_addr: u8) -> Self {
+        Self { i2c_addr, ..self }
     }
 
     /// Set the rotation of the display to one of four values. Defaults to no rotation.
-    pub fn with_rotation(&self, rotation: DisplayRotation) -> Self {
-        Self { rotation, ..*self }
+    pub fn with_rotation(self, rotation: DisplayRotation) -> Self {
+        Self { rotation, ..self }
+    }
+
+    /// Set the SPI chip select (CS) pin to use. The CS pin is not required for the controller for
+    /// function, but can be used if the bus is shared with other devices. If not used, the CS pin
+    /// on the controller should be connected to ground. Ignored when using I2C interface.
+    pub fn with_spi_cs<NEWCS>(self, spi_cs: NEWCS) -> Builder<NEWCS>
+        where NEWCS: OutputPin
+    {
+        Builder {
+            display_size: self.display_size,
+            i2c_addr: self.i2c_addr,
+            rotation: self.rotation,
+            spi_cs,
+        }
     }
 
     /// Finish the builder and use I2C to communicate with the display
-    pub fn connect_i2c<I2C>(&self, i2c: I2C) -> DisplayMode<RawMode<I2cInterface<I2C>>>
+    pub fn connect_i2c<I2C>(self, i2c: I2C) -> DisplayMode<RawMode<I2cInterface<I2C>>>
     where
         I2C: hal::blocking::i2c::Write,
     {
@@ -108,16 +125,28 @@ impl Builder {
 
     /// Finish the builder and use SPI to communicate with the display
     pub fn connect_spi<SPI, DC>(
-        &self,
+        self,
         spi: SPI,
         dc: DC,
-    ) -> DisplayMode<RawMode<SpiInterface<SPI, DC>>>
+    ) -> DisplayMode<RawMode<SpiInterface<SPI, DC, CS>>>
     where
         SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
         DC: OutputPin,
     {
-        let properties =
-            DisplayProperties::new(SpiInterface::new(spi, dc), self.display_size, self.rotation);
-        DisplayMode::<RawMode<SpiInterface<SPI, DC>>>::new(properties)
+        let properties = DisplayProperties::new(
+            SpiInterface::new(spi, dc, self.spi_cs),
+            self.display_size,
+            self.rotation
+        );
+        DisplayMode::<RawMode<SpiInterface<SPI, DC, CS>>>::new(properties)
     }
+}
+
+/// Represents an unused output pin.
+#[derive(Clone, Copy)]
+pub struct NoOutputPin;
+
+impl OutputPin for NoOutputPin {
+    fn set_low(&mut self) { }
+    fn set_high(&mut self) { }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -21,8 +21,6 @@
 //!   GraphicsMode<I2cInterface<I2c<I2C1, (PB8<Alternate<OpenDrain>>, PB9<Alternate<OpenDrain>>)>>>;
 //! ```
 //!
-//! [Example](https://github.com/jamwaffles/sh1106/blob/master/examples/blinky_i2c.rs)
-//!
 //! Here's one for SPI1 on an STM32F103xx:
 //!
 //! ```rust
@@ -48,8 +46,6 @@
 //!     >,
 //! >;
 //! ```
-//!
-//! [Example](https://github.com/jamwaffles/sh1106/blob/master/examples/blinky.rs)
 
 pub mod i2c;
 pub mod spi;

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -20,8 +20,39 @@
 //! type OledDisplay =
 //!   GraphicsMode<I2cInterface<I2c<I2C1, (PB8<Alternate<OpenDrain>>, PB9<Alternate<OpenDrain>>)>>>;
 //! ```
+//!
+//! [Example](https://github.com/jamwaffles/sh1106/blob/master/examples/blinky_i2c.rs)
+//!
+//! Here's one for SPI1 on an STM32F103xx:
+//!
+//! ```rust
+//! # extern crate sh1106;
+//! # extern crate stm32f103xx_hal as hal;
+//! # use hal::gpio::gpioa::{PA5, PA6, PA7};
+//! # use hal::gpio::gpiob::PB1;
+//! # use hal::gpio::{Alternate, Floating, Input, Output, PushPull};
+//! # use hal::spi::Spi;
+//! # use hal::stm32f103xx::SPI1;
+//! # use sh1106::interface::SpiInterface;
+//! pub type OledDisplay = GraphicsMode<
+//!     SpiInterface<
+//!         Spi<
+//!             SPI1,
+//!             (
+//!                 PA5<Alternate<PushPull>>,
+//!                 PA6<Input<Floating>>,
+//!                 PA7<Alternate<PushPull>>,
+//!             ),
+//!         >,
+//!         PB1<Output<PushPull>>,
+//!     >,
+//! >;
+//! ```
+//!
+//! [Example](https://github.com/jamwaffles/sh1106/blob/master/examples/blinky.rs)
 
 pub mod i2c;
+pub mod spi;
 
 /// A method of communicating with sh1106
 pub trait DisplayInterface {
@@ -32,3 +63,4 @@ pub trait DisplayInterface {
 }
 
 pub use self::i2c::I2cInterface;
+pub use self::spi::SpiInterface;

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,0 +1,51 @@
+//! sh1106 SPI interface
+
+use hal;
+use hal::digital::OutputPin;
+
+use super::DisplayInterface;
+
+// TODO: Add to prelude
+/// SPI display interface.
+///
+/// This combines the SPI peripheral and a data/command pin
+pub struct SpiInterface<SPI, DC> {
+    spi: SPI,
+    dc: DC,
+}
+
+impl<SPI, DC> SpiInterface<SPI, DC>
+where
+    SPI: hal::blocking::spi::Write<u8>,
+    DC: OutputPin,
+{
+    /// Create new SPI interface for communciation with sh1106
+    pub fn new(spi: SPI, dc: DC) -> Self {
+        Self { spi, dc }
+    }
+}
+
+impl<SPI, DC> DisplayInterface for SpiInterface<SPI, DC>
+where
+    SPI: hal::blocking::spi::Write<u8>,
+    DC: OutputPin,
+{
+    fn send_commands(&mut self, cmds: &[u8]) -> Result<(), ()> {
+        self.dc.set_low();
+
+        self.spi.write(&cmds).map_err(|_| ())?;
+
+        self.dc.set_high();
+
+        Ok(())
+    }
+
+    fn send_data(&mut self, buf: &[u8]) -> Result<(), ()> {
+        // 1 = data, 0 = command
+        self.dc.set_high();
+
+        self.spi.write(&buf).map_err(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -5,46 +5,56 @@ use hal::digital::OutputPin;
 
 use super::DisplayInterface;
 
-// TODO: Add to prelude
 /// SPI display interface.
 ///
 /// This combines the SPI peripheral and a data/command pin
-pub struct SpiInterface<SPI, DC> {
+pub struct SpiInterface<SPI, DC, CS> {
     spi: SPI,
     dc: DC,
+    cs: CS,
 }
 
-impl<SPI, DC> SpiInterface<SPI, DC>
+impl<SPI, DC, CS> SpiInterface<SPI, DC, CS>
 where
     SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
+    CS: OutputPin,
 {
     /// Create new SPI interface for communciation with sh1106
-    pub fn new(spi: SPI, dc: DC) -> Self {
-        Self { spi, dc }
+    pub fn new(spi: SPI, dc: DC, mut cs: CS) -> Self {
+        cs.set_high();
+
+        Self { spi, dc, cs }
     }
 }
 
-impl<SPI, DC> DisplayInterface for SpiInterface<SPI, DC>
+impl<SPI, DC, CS> DisplayInterface for SpiInterface<SPI, DC, CS>
 where
     SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
+    CS: OutputPin,
 {
     fn send_commands(&mut self, cmds: &[u8]) -> Result<(), ()> {
+        self.cs.set_low();
         self.dc.set_low();
 
         self.spi.write(&cmds).map_err(|_| ())?;
 
         self.dc.set_high();
+        self.cs.set_high();
 
         Ok(())
     }
 
     fn send_data(&mut self, buf: &[u8]) -> Result<(), ()> {
+        self.cs.set_low();
+
         // 1 = data, 0 = command
         self.dc.set_high();
 
         self.spi.write(&buf).map_err(|_| ())?;
+
+        self.cs.set_high();
 
         Ok(())
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,5 +2,5 @@
 
 pub use super::displayrotation::DisplayRotation;
 pub use super::displaysize::DisplaySize;
-pub use super::interface::I2cInterface;
+pub use super::interface::{I2cInterface, SpiInterface};
 pub use super::mode::GraphicsMode;


### PR DESCRIPTION
Add back the SPI interface, enhanced with an optional chip select pin and an example. Closes #2.