### PR TITLE
Use correct addressing commands and fix display size/alignment

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -15,15 +15,12 @@ pub enum Command {
     Invert(bool),
     /// Turn display on or off.
     DisplayOn(bool),
-    /// Setup column start and end address
-    /// values range from 0-127
-    /// This is only for horizontal or vertical addressing mode
-    ColumnAddress(u8, u8),
-    /// Setup page start and end address
-    /// This is only for horizontal or vertical addressing mode
-    PageAddress(Page, Page),
-    /// Set GDDRAM page start address for Page addressing mode
-    PageStart(Page),
+    /// Set column address lower 4 bits
+    ColumnAddressLow(u8),
+    /// Set column address higher 4 bits
+    ColumnAddressHigh(u8),
+    /// Set page address
+    PageAddress(Page),
     /// Set display start line from 0-63
     StartLine(u8),
     /// Reverse columns from 127-0
@@ -64,9 +61,9 @@ impl Command {
             Command::AllOn(on) => ([0xA4 | (on as u8), 0, 0, 0, 0, 0, 0], 1),
             Command::Invert(inv) => ([0xA6 | (inv as u8), 0, 0, 0, 0, 0, 0], 1),
             Command::DisplayOn(on) => ([0xAE | (on as u8), 0, 0, 0, 0, 0, 0], 1),
-            Command::ColumnAddress(start, end) => ([0x21, start, end, 0, 0, 0, 0], 3),
-            Command::PageAddress(start, end) => ([0x22, start as u8, end as u8, 0, 0, 0, 0], 3),
-            Command::PageStart(page) => ([0xB0 | (page as u8), 0, 0, 0, 0, 0, 0], 1),
+            Command::ColumnAddressLow(addr) => ([0xF & addr, 0, 0, 0, 0, 0, 0], 1),
+            Command::ColumnAddressHigh(addr) => ([0x10 | (0xF & addr), 0, 0, 0, 0, 0, 0], 1),
+            Command::PageAddress(page) => ([0xB0 | (page as u8), 0, 0, 0, 0, 0, 0], 1),
             Command::StartLine(line) => ([0x40 | (0x3F & line), 0, 0, 0, 0, 0, 0], 1),
             Command::SegmentRemap(remap) => ([0xA0 | (remap as u8), 0, 0, 0, 0, 0, 0], 1),
             Command::Multiplex(ratio) => ([0xA8, ratio, 0, 0, 0, 0, 0], 2),
@@ -96,21 +93,21 @@ impl Command {
 #[derive(Debug, Clone, Copy)]
 pub enum Page {
     /// Page 0
-    Page0 = 0xb0,
+    Page0 = 0,
     /// Page 1
-    Page1 = 0xb1,
+    Page1 = 1,
     /// Page 2
-    Page2 = 0xb2,
+    Page2 = 2,
     /// Page 3
-    Page3 = 0xb3,
+    Page3 = 3,
     /// Page 4
-    Page4 = 0xb4,
+    Page4 = 4,
     /// Page 5
-    Page5 = 0xb5,
+    Page5 = 5,
     /// Page 6
-    Page6 = 0xb6,
+    Page6 = 6,
     /// Page 7
-    Page7 = 0xb7,
+    Page7 = 7,
 }
 
 impl From<u8> for Page {

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -7,6 +7,8 @@ pub enum DisplaySize {
     Display128x64,
     /// 128 by 32 pixels
     Display128x32,
+    /// 132 by 64 pixels
+    Display132x64,
 }
 
 impl DisplaySize {
@@ -16,6 +18,16 @@ impl DisplaySize {
         match *self {
             DisplaySize::Display128x64 => (128, 64),
             DisplaySize::Display128x32 => (128, 32),
+            DisplaySize::Display132x64 => (132, 64),
+        }
+    }
+
+    /// Get the panel column offset from DisplaySize
+    pub fn column_offset(&self) -> u8 {
+        match *self {
+            DisplaySize::Display128x64 => 2,
+            DisplaySize::Display128x32 => 2,
+            DisplaySize::Display132x64 => 0,
         }
     }
 }


### PR DESCRIPTION
I changed the addressing commands to the correct ones for this controller and implemented incrementing the page address as this controller doesn't do it automatically.

Also I added the 132x64 display size which is the maximum size this controller supports, and added a "panel column offset" to the smaller sizes because it seems that on modules in the wild it's common to have a panel that uses the middle 128 columns of the 132 available, as opposed to the leftmost 128. I suppose it's possible to have a module where the leftmost or rightmost columns are used instead, but the common case seems to be to use the middle ones.

With this commit at least the display module I have seems to work perfectly with no garbled pixels and with correct column alignment.

Closes #1 and #3.