### PR TITLE
Make NoOutputPin generic

### DIFF
--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+    let mut disp: GraphicsMode<_> = Builder::<()>::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
     disp.flush().unwrap();

--- a/examples/graphics_128x32.rs
+++ b/examples/graphics_128x32.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new()
+    let mut disp: GraphicsMode<_> = Builder::<()>::new()
         .with_size(DisplaySize::Display128x32)
         .connect_i2c(i2c)
         .into();

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -69,7 +69,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+    let mut disp: GraphicsMode<_> = Builder::<()>::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
     disp.flush().unwrap();

--- a/examples/pixelsquare.rs
+++ b/examples/pixelsquare.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+    let mut disp: GraphicsMode<_> = Builder::<()>::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
     disp.flush().unwrap();

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -69,7 +69,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new()
+    let mut disp: GraphicsMode<_> = Builder::<()>::new()
         // Set initial rotation at 90 degrees clockwise
         .with_rotation(DisplayRotation::Rotate90)
         .connect_i2c(i2c)

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
         1000,
     );
 
-    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+    let mut disp: GraphicsMode<_> = Builder::<()>::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
     disp.flush().unwrap();


### PR DESCRIPTION
This library doesn't seem to work OK with `stm32f4xx-hal` in its current incarnation. The problem seems to be the fact that `NoOutputPin` implements `OutputPin<Error=()>`, while `stm32f4xx-hal` expects `<Error=Infallible>`.
The solution I've found was to make `NoOutputPin` generic, through a `PinE` type argument.
I haven't found a way to avoid this `Builder::<()>::new()` nonsense. I would expect the compiler to infer that, but apparently that's not the case.
Anyway, I hope this PR is useful. I'll be happy to make changes if it's at least partially usable.