### PR TITLE
Add public method for setting screen contrast (brightness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ with the [embedded-hal](crates.io/crates/embedded-hal) traits for maximum portab
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#20](https://github.com/jamwaffles/sh1106/pull/20) Add `set_contrast` method to set the display contrast/brightness.
+
 ## [0.3.1] - 2020-03-21
 
 ### Fixed

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -160,6 +160,11 @@ where
     pub fn set_rotation(&mut self, rot: DisplayRotation) -> Result<(), DI::Error> {
         self.properties.set_rotation(rot)
     }
+
+    /// Set the display contrast
+    pub fn set_contrast(&mut self, contrast: u8) -> Result<(), DI::Error> {
+        self.properties.set_contrast(contrast)
+    }
 }
 
 #[cfg(feature = "graphics")]

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -187,4 +187,9 @@ where
             }
         }
     }
+
+    /// Set the display contrast
+    pub fn set_contrast(&mut self, contrast: u8) -> Result<(), DI::Error> {
+        Command::Contrast(contrast).send(&mut self.iface)
+    }
 }


### PR DESCRIPTION
When browsing through the API, I was surprised it's not possible to change the brightness of these displays, but it turns out it just wasn't exposed here yet :smile: 

I've tested this on my own SH1106 display and it appears to work pretty well. It does look like the driver could be fine-tuned to show even darker content using the [precharge period](https://github.com/olikraus/u8g2/issues/98)? But I'm not familiar with how that works, and the helpful link @limpkin posted to relevant documentation on that issue appears to be dead. The brightness range is sufficient for my own use case in the meantime though.