### PR TITLE
Support 128x64 displays with no X offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ with the [embedded-hal](crates.io/crates/embedded-hal) traits for maximum portab
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#22](https://github.com/jamwaffles/sh1106/pull/22) Add `DisplaySize::Display128x64NoOffset` variant for 128x64 displays that don't use a 132x64 buffer internally.
+
 ## [0.3.2] - 2020-04-30
 
 ### Added
@@ -69,9 +73,9 @@ Upgrade to new embedded-graphics `0.6.0-alpha.1` release. Please see the [embedd
 - **(breaking)** #9 Upgraded to [embedded-graphics](https://crates.io/crates/embedded-graphics) 0.6.0-alpha.1
 
 <!-- next-url -->
+
 [unreleased]: https://github.com/jamwaffles/sh1106/compare/v0.3.2...HEAD
 [0.3.2]: https://github.com/jamwaffles/sh1106/compare/v0.3.1...v0.3.2
-
 [0.3.1]: https://github.com/jamwaffles/sh1106/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jamwaffles/sh1106/compare/v0.3.0-alpha.4...v0.3.0
 [0.3.0-alpha.4]: https://github.com/jamwaffles/sh1106/compare/v0.3.0-alpha.3...v0.3.0-alpha.4

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -5,6 +5,8 @@
 pub enum DisplaySize {
     /// 128 by 64 pixels
     Display128x64,
+    /// 128 by 64 pixels without 2px X offset
+    Display128x64NoOffset,
     /// 128 by 32 pixels
     Display128x32,
     /// 132 by 64 pixels
@@ -16,6 +18,7 @@ impl DisplaySize {
     pub fn dimensions(self) -> (u8, u8) {
         match self {
             DisplaySize::Display128x64 => (128, 64),
+            DisplaySize::Display128x64NoOffset => (128, 64),
             DisplaySize::Display128x32 => (128, 32),
             DisplaySize::Display132x64 => (132, 64),
         }
@@ -25,6 +28,7 @@ impl DisplaySize {
     pub fn column_offset(self) -> u8 {
         match self {
             DisplaySize::Display128x64 => 2,
+            DisplaySize::Display128x64NoOffset => 0,
             DisplaySize::Display128x32 => 2,
             DisplaySize::Display132x64 => 0,
         }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -60,8 +60,9 @@ where
 
         match self.display_size {
             DisplaySize::Display128x32 => Command::ComPinConfig(false).send(&mut self.iface),
-            DisplaySize::Display128x64 => Command::ComPinConfig(true).send(&mut self.iface),
-            DisplaySize::Display132x64 => Command::ComPinConfig(true).send(&mut self.iface),
+            DisplaySize::Display128x64
+            | DisplaySize::Display128x64NoOffset
+            | DisplaySize::Display132x64 => Command::ComPinConfig(true).send(&mut self.iface),
         }?;
 
         Command::Contrast(0x80).send(&mut self.iface)?;


### PR DESCRIPTION
Adds a new `DisplaySize` variant called `DisplaySize::Display128x64NoOffset` which has zero column offset.

A reasonably kludgy solution. The builder might want to add a `with_offset` method in the future, but for now this should hopefully fix the specific case found in #21.

@antonok-edm can you test your display with this branch and see if it works please? I don't have the right hardware to check it at the moment.

Closes #21