### PR TITLE
Fixed command bytes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -74,10 +74,10 @@ impl Command {
                 ([0xD5, ((0xF & fosc) << 4) | (0xF & div), 0, 0, 0, 0, 0], 2)
             }
             Command::PreChargePeriod(phase1, phase2) => (
-                [0x22, ((0xF & phase2) << 4) | (0xF & phase1), 0, 0, 0, 0, 0],
+                [0xD9, ((0xF & phase2) << 4) | (0xF & phase1), 0, 0, 0, 0, 0],
                 2,
             ),
-            Command::VcomhDeselect(level) => ([0x35, (level as u8) << 4, 0, 0, 0, 0, 0], 2),
+            Command::VcomhDeselect(level) => ([0xDB, (level as u8) << 4, 0, 0, 0, 0, 0], 2),
             Command::Noop => ([0xE3, 0, 0, 0, 0, 0, 0], 1),
             Command::ChargePump(en) => ([0xAD, 0x8A | (en as u8), 0, 0, 0, 0, 0], 2),
         };


### PR DESCRIPTION
Changed first bytes for `Command::PreChargePeriod` and `Command::VcomhDeselect` to be what they should be in the datasheet (`0xD9` and `0xDB`, respectively).

This fix got the driver working properly for my hardware setup (Raspberry Pi Zero W + [WaveShare SH1106 HAT](https://www.waveshare.com/1.3inch-oled-hat.htm)). 
Before this fix, the display would behave differently in based on what seemed to be background cosmic radiation; sometimes it would work perfectly, sometimes it would go dark after a few seconds of displaying something.

This relates to issue https://github.com/jamwaffles/sh1106/issues/7.

