### PR TITLE
bump embedded-graphics-core: 0.3.2->0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ circle-ci = { repository = "jamwaffles/sh1106", branch = "master" }
 
 [dependencies]
 embedded-hal = "0.2.3"
-embedded-graphics-core = { version = "0.3.2", optional = true }
+embedded-graphics-core = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.6.10"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.0"
 heapless = "0.7.10"
 panic-semihosting = "0.5.2"
 cortex-m-rtic = "0.5.9"


### PR DESCRIPTION
There was some trait bound issue compiling the minimal example for the Raspberry Pi while using the I²C interface (`rppal` crate with `hal` feature enabled).

Updating to `embedded-graphics-core = 0.4.0` solves the problem and results in a working display setup.