### PR TITLE
Allow the underlying interface to be released consuming the DisplayProperties

### DIFF
--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -26,6 +26,7 @@ where
     I2C: hal::blocking::i2c::Write<Error = CommE>,
 {
     type Error = Error<CommE, ()>;
+    type Interface = I2C;
 
     fn init(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -81,5 +82,9 @@ where
         }
 
         Ok(())
+    }
+
+    fn release(self) -> Self::Interface {
+        self.i2c
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -55,6 +55,8 @@ pub mod spi;
 pub trait DisplayInterface {
     /// Interface error type
     type Error;
+    /// Underlying interface type
+    type Interface;
 
     /// Initialize device.
     fn init(&mut self) -> Result<(), Self::Error>;
@@ -62,6 +64,8 @@ pub trait DisplayInterface {
     fn send_commands(&mut self, cmd: &[u8]) -> Result<(), Self::Error>;
     /// Send data to display.
     fn send_data(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+    /// Release the interface
+    fn release(self) -> Self::Interface;
 }
 
 pub use self::{i2c::I2cInterface, spi::SpiInterface};

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -33,6 +33,7 @@ where
     CS: OutputPin<Error = PinE>,
 {
     type Error = Error<CommE, PinE>;
+    type Interface = (SPI, DC, CS);
 
     fn init(&mut self) -> Result<(), Self::Error> {
         self.cs.set_high().map_err(Error::Pin)
@@ -58,4 +59,9 @@ where
 
         self.cs.set_high().map_err(Error::Pin)
     }
+
+    fn release(self) -> Self::Interface {
+        (self.spi, self.dc, self.cs)
+    }
+    
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -167,4 +167,9 @@ where
     pub fn set_contrast(&mut self, contrast: u8) -> Result<(), DI::Error> {
         Command::Contrast(contrast).send(&mut self.iface)
     }
+
+    /// Release the underlying interface
+    pub fn release_interface(self) -> DI::Interface {
+        self.iface.release()
+    }
 }


### PR DESCRIPTION
Necessary for https://github.com/SCingolani/rp-hal-boards/tree/pololu-threepi-plus-2040 where Spi interface needs to be reconfigured and shared between two devices. In between, the SCK Pin of the SH1106 has to be set to `FunctionNull` to avoid driving it while using the other device.

This change consumes the `DisplayProperties` and returns to the user both the Spi instance and the pins.